### PR TITLE
ボイスチャンネルのログで設定されているタイムゾーンの変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM node:14.21.1-buster
 
 WORKDIR /usr/app
 
+#ログの表示をJSTに変更する
+RUN apt-get update && apt install -y tzdata && apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV TZ Asia/Tokyo
+
 COPY . .
 RUN npm install
 RUN npm run build


### PR DESCRIPTION
<img width="531" alt="スクリーンショット 2023-04-16 18 38 35" src="https://user-images.githubusercontent.com/29473019/232290267-aeedfa1a-75ea-4dac-abfe-0f1666587872.png">

k3s環境に移行後jst表記のログで無くなってしまったため修正